### PR TITLE
added verification to RinchiDecompositionOutput constructor that the …

### DIFF
--- a/jna-rinchi-api/src/main/java/io/github/dan2097/jnarinchi/JnaRinchi.java
+++ b/jna-rinchi-api/src/main/java/io/github/dan2097/jnarinchi/JnaRinchi.java
@@ -532,8 +532,14 @@ public class JnaRinchi
 				
 		String err = errorBuffer.toString();
 		if (err.isEmpty())
-			return new RinchiDecompositionOutput(direction, inchis, auxInfos, roles, 
-					Status.SUCCESS, 0, "");
+			try {
+				return new RinchiDecompositionOutput(direction, inchis, auxInfos, roles,
+						Status.SUCCESS, 0, "");
+			} catch (IllegalArgumentException exception) {
+				// we end up here if the number of InChIs, auxiliary information and reaction component role is not equal
+				return new RinchiDecompositionOutput(direction, null, null, null,
+						Status.ERROR, ERROR_CODE_DECOMPOSE_FROM_LINES, exception.getMessage());
+			}
 		else {
 			//Generally this should never happen. Otherwise, it is a bug in RInChI native C++ code
 			return new RinchiDecompositionOutput(direction, null, null, null, 

--- a/jna-rinchi-api/src/main/java/io/github/dan2097/jnarinchi/RinchiDecompositionOutput.java
+++ b/jna-rinchi-api/src/main/java/io/github/dan2097/jnarinchi/RinchiDecompositionOutput.java
@@ -24,6 +24,7 @@ package io.github.dan2097.jnarinchi;
  * @author Nikolay Kochev
  */
 public class RinchiDecompositionOutput extends Output {
+	private final static int ARRAY_IS_NULL = -1;
 	private final ReactionDirection direction;		
 	private final String[] inchis;
 	private final String[] auxInfos;
@@ -34,6 +35,17 @@ public class RinchiDecompositionOutput extends Output {
 	{
 		super(status, errorCode, errorMessage);
 		this.direction = direction;
+
+		// make sure that the number of elements in the arrays storing the individual InChIs, auxiliary information
+		// and reaction component roles is equal; otherwise, we throw an exception
+		final int noElementsInchis = inchis == null ? ARRAY_IS_NULL : inchis.length;
+		final int noElementsAuxInfo = auxInfos == null ? ARRAY_IS_NULL : auxInfos.length;
+		final int noElementsRoles = roles == null ? ARRAY_IS_NULL : roles.length;
+		if (noElementsInchis != noElementsAuxInfo || noElementsAuxInfo != noElementsRoles) {
+			throw new IllegalArgumentException("The number of InChIs (" + noElementsInchis + "), auxiliary information (" +
+					noElementsAuxInfo + ") and reaction component roles (" + noElementsRoles + ") must be equal.");
+		}
+
 		this.inchis = inchis;
 		this.auxInfos = auxInfos;
 		this.roles = roles;

--- a/jna-rinchi-api/src/test/java/io/github/dan2097/jnarinchi/RinchiDecompositionOutputTest.java
+++ b/jna-rinchi-api/src/test/java/io/github/dan2097/jnarinchi/RinchiDecompositionOutputTest.java
@@ -1,0 +1,65 @@
+package io.github.dan2097.jnarinchi;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RinchiDecompositionOutputTest {
+
+    // inchis, auxInfo, roles are null; not expected to raise an exception
+    @Test
+    void testRinchiDecompositionOutput_constructor_ThreeArraysNull() {
+        Assertions.assertDoesNotThrow(
+                () -> new RinchiDecompositionOutput(
+                        ReactionDirection.FORWARD,
+                        null,
+                        null,
+                        null,
+                        Status.SUCCESS,
+                        0,
+                        ""),
+                "Testing constructor, the arrays inchis, auxInfo, roles are all null; not expected to raise an exception.");
+    }
+
+    // inchis, auxInfo, roles have three elements each; not expected to raise an exception
+    @Test
+    void testRinchiDecompositionOutput_constructor_ThreeArraysThreeElements() {
+        Assertions.assertDoesNotThrow(
+                () -> new RinchiDecompositionOutput(
+                        ReactionDirection.FORWARD,
+                        new String[]{"inchi1", "inchi2", "inchi3"},
+                        new String[]{"auxInfo1", "auxInfo2", "auxInfo3"},
+                        new ReactionComponentRole[]{ReactionComponentRole.REAGENT, ReactionComponentRole.REAGENT, ReactionComponentRole.PRODUCT},
+                        Status.SUCCESS,
+                        0,
+                        ""),
+                "Testing constructor, the arrays inchis, auxInfo, roles have three elements each; not expected to raise an exception.");
+    }
+
+    // inchis, auxInfo with three elements each, roles is null; expected to raise an exception
+    @Test
+    void testRinchiDecompositionOutput_constructor_TwoArraysThreeElements_OneArrayNull() {
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> new RinchiDecompositionOutput(
+                ReactionDirection.FORWARD,
+                new String[]{"inchi1", "inchi2", "inchi3"},
+                new String[]{"auxInfo1", "auxInfo2", "auxInfo3"},
+                null,
+                Status.SUCCESS,
+                0,
+                ""),
+                "Testing constructor, the arrays inchis, auxInfo have three elements each, roles is null; expected to raise an exception.");
+    }
+
+    // inchis, auxInfo with three elements each, roles with two elements; expected to raise an exception
+    @Test
+    void testRinchiDecompositionOutput_constructor_TwoArraysThreeElements_OneArrayTwoElements() {
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> new RinchiDecompositionOutput(
+                        ReactionDirection.FORWARD,
+                        new String[]{"inchi1", "inchi2", "inchi3"},
+                        new String[]{"auxInfo1", "auxInfo2", "auxInfo3"},
+                        new ReactionComponentRole[]{ReactionComponentRole.REAGENT, ReactionComponentRole.PRODUCT},
+                        Status.SUCCESS,
+                        0,
+                        ""),
+                "Testing constructor, the arrays inchis, auxInfo have three elements each, roles has two elements; expected to raise an exception.");
+    }
+}


### PR DESCRIPTION
…three arrays inchis, auxInfos and roles are either all null or got the same number of elements; catching the IllegalArgumentException thrown by the RinchiDecompositionOutput constructor in JnaRinchi and converting it to an error message; put in test cases for the RinchiDecompositionOutput constructor